### PR TITLE
rename get_type by to_string

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use crate::builtin;
+use std::string::ToString;
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum LType {
@@ -25,8 +26,8 @@ pub enum LType {
     Newline
 }
 
-impl LType {
-    pub fn get_type(&self) -> String {
+impl ToString for LType {
+    fn to_string(&self) -> String {
         match self {
             Self::LParen => String::from("Opening Parenthese"),
             Self::RParen => String::from("Closing Parenthese"),


### PR DESCRIPTION
Bonjour, je ne sais pas si vous êtes toujours sur le projet, mais j'ai fait une petite amélioration.

J'ai implémenté le trait [ToString](https://doc.rust-lang.org/std/string/trait.ToString.html) à l'enum `LType`. Et j'ai supprimé la fonction `get_type`. Je pense que ToString est mieux adapte pour cette utilisation